### PR TITLE
set the real free cluster count using fatfs.

### DIFF
--- a/arm9/source/fs.c
+++ b/arm9/source/fs.c
@@ -502,6 +502,36 @@ static bool backupEssentialFiles(void)
     return ok;
 }
 
+bool getFreeSpace(const char *path, u64* out_size, u32* out_clusters)
+{
+    DWORD free_clusters = 0;
+    FATFS* fs = NULL;
+
+    // todo: verify both paths.
+    if (!strncmp(path, "sdmc:", strlen("sdmc:")))
+    {
+        fs = &sdFs;
+    }
+    else if (!strncmp(path, "nand:", strlen("nand:")))
+    {
+        fs = &nandFs;
+    }
+    else
+    {
+        return false;
+    }
+
+    if (FR_OK != f_getfree(path, &free_clusters, &fs))
+    {
+        return false;
+    }
+
+    if (out_size) *out_size = (u64)free_clusters * (u64)fs->csize;
+    if (out_clusters) *out_clusters = free_clusters;
+
+    return true;
+}
+
 bool doLumaUpgradeProcess(void)
 {
     bool ok = true, ok2 = true;

--- a/arm9/source/fs.h
+++ b/arm9/source/fs.h
@@ -44,5 +44,6 @@ bool findPayload(char *path, u32 pressed);
 bool payloadMenu(char *path, bool *hasDisplayedMenu);
 u32 firmRead(void *dest, u32 firmType);
 void findDumpFile(const char *folderPath, char *fileName);
+bool getFreeSpace(const char *path, u64* out_size, u32* out_clusters);
 
 bool doLumaUpgradeProcess(void);


### PR DESCRIPTION
(So full disclaimer, i have zero knowledge of the 3DS or making patches, as well as this being the first time using ghidra, lol).

This change uses fatfs to get the total free cluster count and write that instead of marking it completely empty. Looking at the original patch, we only had 4 instructions to work with, which wasn't enough to load a 32bit value and write back to an address. It also wasn't enough space to insert our own thumb function to branch to.

I decided to look at the asm, to do this i dumped the full arm9 mem using `fileWrite()` and loading it in ghidra. I jumped to the pattern you used and looked at the surrounding code. I noticed that it was branching to another function and then after checking the return value. Afaik, the label that it jumps to is only ever called in this location, so it looks like its safe to completely overwrite with our own code, and it has a lot of space to work with :)

The second pattern is just the full code of the instruction. It could probably be simplified, or use wildcards to filter out registers in the instruction, in case they change between updates.

---

A few questions if you don't mind:
- How to you properly dump the arm9 binary? I originally followed this https://ihaveamac.github.io/dump.html which gave me arm9.bin, however i could not find the code in there (or much of anything?).
- Does this arm9 code change between fw updates? I've only tried this on fw  11.13.0-45E
- I noticed that if i nop the jump to the label (basically nop the 4 instructions in the pattern) that the system reports the correct free block size anyway. Any idea why that is?
